### PR TITLE
:memo: Update IMAP Description

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -46,7 +46,7 @@ This documentation is for anyone interested in the NVVS DevOps team and its core
 | --- | --- |
 | [DNS](documentation/products/dns.html) | Public name resolution for staff devices when local and remote. This service protects user traffic by forwarding queries to Protective DNS. |
 | [DHCP](documentation/products/dhcp.html) | Automatic device configuration of MoJO DNS. This service helps devices when connected at sites reach the internet. |
-| [IMAP](https://github.com/ministryofjustice/staff-infrastructure-monitoring) | The Infrastructure Monitoring and Alerting Platform aims to allow service owners and support teams to monitor the health of the MoJ infrastructure and identify failures as early as possible ahead of the end users noticing and reporting them. |
+| [IMAP](https://github.com/ministryofjustice/staff-infrastructure-monitoring) | Our Infrastructure Monitoring and Alerting Platform allows us to monitor the health of our infrastructure and products. |
 | [NACS](https://github.com/ministryofjustice/network-access-control-admin) | The Network Access Control service authenticates access to the network at a device level. |
 | [Log Shipping](https://github.com/ministryofjustice/staff-device-logging-infrastructure) | This is the Log Shipping infrastructure used by the Ministry of Justice to forward logs to the Operational Security Team. |
 | [PKI](https://github.com/ministryofjustice/staff-infrastructure-certificate-services) | Public Key Infrastructure for devices and users. This repository can redeploy the EC2 instances which Entrust build their managed service on. |


### PR DESCRIPTION
The intention is now that the Monitoring Platform is not the go to solution for other teams monitoring concerns. Updating this high level statement reflects this. 