### PR TITLE
Amend path for publishing changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,4 +16,4 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Publish
-      run: /scripts/deploy.sh
+      run: /usr/local/bin/package


### PR DESCRIPTION
ND-92 - The change from V3 to V4 introduced some breaking changes. The path to the publish script has been changed to represent this.

https://github.com/ministryofjustice/tech-docs-github-pages-publisher/tree/1ffb41bc97a99d46ffdd03a491a53efb68488d33