### PR TITLE
Update of Network, Voice and Video Service DevOps (NVVS DevOps) page

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#nvvs-devops"
-title: NVVS DevOps
-last_reviewed_on: 2023-10-20
+title: LAN/WiFi-DevOps
+last_reviewed_on: 2024-04-10
 review_in: 3 months
 ---
 
@@ -9,7 +9,7 @@ review_in: 3 months
 
 # Network, Voice and Video Service DevOps (NVVS DevOps)
 
-The NVVS DevOps team sit within the [Network Services](https://peoplefinder.service.gov.uk/teams/network-services) area. Our [Team](documentation/general-information/our-team.html) is made up of Developers, Product Managers and Operations Managers.
+The LAN/Wifi-DevOps team sit within the [Network Services](https://peoplefinder.service.gov.uk/teams/network-services) area. Our [Team](documentation/general-information/our-team.html) is made up of Developers, Product Managers and Operations Managers.
 Please see [Our Products](#our-products) to find a list of applications we are currently responsible for.
 
 
@@ -17,7 +17,7 @@ Please see [Our Products](#our-products) to find a list of applications we are c
 
 ## Who is this for?
 
-This documentation is for anyone interested in the NVVS DevOps team and its core values.
+This documentation is for anyone interested in the  LAN/WiFi-DevOps team and its core values.
 
 ## General Information
 
@@ -49,7 +49,6 @@ This documentation is for anyone interested in the NVVS DevOps team and its core
 | [DHCP](documentation/products/dhcp.html) | Automatic device configuration of MoJO DNS. This service helps devices when connected at sites reach the internet. |
 | [IMAP](https://github.com/ministryofjustice/nvvs-devops-monitor) | Our Infrastructure Monitoring and Alerting Platform allows us to monitor the health of our infrastructure and products. |
 | [NACS](documentation/products/nacs.html) | The Network Access Control service authenticates access to the network at a device level. |
-| [Log Shipping](https://github.com/ministryofjustice/staff-device-logging-infrastructure) | This is the Log Shipping infrastructure used by the Ministry of Justice to forward logs to the Operational Security Team. |
 | [PKI](https://github.com/ministryofjustice/staff-infrastructure-certificate-services) | Public Key Infrastructure for devices and users. This repository can redeploy the EC2 instances which Entrust build their managed service on. |
 | [SMTP Relay](https://github.com/ministryofjustice/staff-infrastructure-smtp-relay-server) | The Simple Mail Transort Protocol Relay service allows legacy MoJ applications and services to send unauthenticated email to staff devices and brings this system in house. |
 | [Tech Docs Monitor](https://github.com/ministryofjustice/tech-docs-monitor) | A solution for monitoring documentation, also known as Daniel The Manual Spaniel 🐶 |
@@ -62,9 +61,11 @@ This documentation is for anyone interested in the NVVS DevOps team and its core
 | [GitHub Team](https://github.com/orgs/ministryofjustice/teams/nvvs-devops-admins/repositories) | Repositories that NVVS DevOps access listed by GitHub
 
 ## Contact Us
+Natalie Navickas -Product Manager: natalie.navickas@justice.gov.uk
+Tom Wells - Associate Product Manager: thomas.wells2@justice.gov.uk
+
 ## Questions and Queries
 -	We have an open slack channel named [#ask-nvvs-devops](https://mojdt.slack.com/archives/C026AFE617T). On here you can find team updates and post questions and queries
--	You can also email us directly at NVVSDevOps@justice.gov.uk
 
 ## Resource Request
 -	Our team can be found on the technology portal for resource requests. You can find our resource request survey from the homepage by going request something, then selecting networks and then finally clicking network services – resource request.

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -9,11 +9,8 @@ review_in: 3 months
 
 # Network, Voice and Video Service DevOps (NVVS DevOps)
 
-The LAN/Wifi-DevOps team sit within the [Network Services](https://peoplefinder.service.gov.uk/teams/network-services) area. Our [Team](documentation/general-information/our-team.html) is made up of Developers, Product Managers and Operations Managers.
+LAN/WiFi-DevOps, formerly NVVS DevOps, sit within the [Network Services](https://peoplefinder.service.gov.uk/teams/network-services) area. Our [Team](documentation/general-information/our-team.html) is made up of Developers, Product Managers and Operations Managers.
 Please see [Our Products](#our-products) to find a list of applications we are currently responsible for.
-
-
-
 
 ## Who is this for?
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -7,7 +7,7 @@ review_in: 3 months
 
 <link rel="icon" type="image/x-icon" href="favicon.ico">
 
-# Network, Voice and Video Service DevOps (NVVS DevOps)
+# LAN/WiFi-DevOps
 
 LAN/WiFi-DevOps, formerly NVVS DevOps, sit within the [Network Services](https://peoplefinder.service.gov.uk/teams/network-services) area. Our [Team](documentation/general-information/our-team.html) is made up of Developers, Product Managers and Operations Managers.
 Please see [Our Products](#our-products) to find a list of applications we are currently responsible for.


### PR DESCRIPTION
Update of team name to LAN/WiFi-DevOps
Removal of Log Shipping as product 
Removal of old team email (NVVSDevOps@justice.gov.uk) 
Addition of Tom and Natalie in Contact Us section