### PR TITLE
Update joining-nvvs-devops-team

### DIFF
--- a/source/documentation/team-guide/joining-nvvs-devops-team.html.md.erb
+++ b/source/documentation/team-guide/joining-nvvs-devops-team.html.md.erb
@@ -1,8 +1,8 @@
 ---
 owner_slack: "#nvvs-devops"
-title: Joining the NVVS DevOps team
-last_reviewed_on: 2023-12-20
-review_in: 2 months
+title: Joining the LAN/wIfI-DevOps team
+last_reviewed_on: 2024-04-12
+review_in: 4 months
 ---
 
 # <%= current_page.data.title %>
@@ -13,7 +13,7 @@ Welcome to the team! Below is some information that you might find useful.
 
 - Our Product and Dev team have a stand up every Monday - Friday from 9:30 - 9:45
 - Our sprints are two weeks and start on Wednesdays.
-- We plan our sprints through the GitHub extension [Zenhub](https://app.zenhub.com/workspaces/nvvs-devops-622a0b371800e400133bb924/board).
+- We plan our sprints through the GitHub extension [Jira](https://dsdmoj.atlassian.net/jira/software/c/projects/ND/boards/1430).
 
 ### Team
 
@@ -55,8 +55,9 @@ If you can't make standup, post your standup update here.
 
 #### #nvvs-devops
 
-The [#nvvs-devops](https://mojdt.slack.com/archives/C01J2L0SC0P) was previosly the our team channel, it's been replaced by the #nvvs-devops-team-chat.
-It has very little communication posted these days. Likely will be closed in future.
+The [#nvvs-devops](https://mojdt.slack.com/archives/C01J2L0SC0P) was previously our team channel, it's been replaced by the #nvvs-devops-team-chat, which is used for the reasons mentioned above.
+
+Now, we use this channel to update the wider community on what we are working on. It's particularly important as the people who support our Out of Hours service are in there, and can be kept up to date with changes we make to our environments.
 
 #### #ask-nvvs-devops
 
@@ -79,7 +80,6 @@ To add or close issues in our GitHub Project,
 - Management/Adminstration: you need to join the [nvvs-devops-writers](https://github.com/orgs/ministryofjustice/teams/nvvs-devops-writers) team on GitHub.
 
 You can request to join or post a message in [#ask-nvvs-devops](https://mojdt.slack.com/archives/C026AFE617T) channel and someone in the team will help you.
-
 
 ### Learning and Development
 


### PR DESCRIPTION
ND-295 changes to reflect current practice.
Zenhub referenced replaced with Jira.
#NVVS-DEVOPS use case updated.