### PR TITLE
Update to content

### DIFF
--- a/source/documentation/team-guide/joining-nvvs-devops-team.html.md.erb
+++ b/source/documentation/team-guide/joining-nvvs-devops-team.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#nvvs-devops"
 title: Joining the LAN/wIfI-DevOps team
-last_reviewed_on: 2024-04-12
+last_reviewed_on: 2024-08-15
 review_in: 4 months
 ---
 
@@ -31,7 +31,6 @@ When you join the team, we want you to feel welcome and included. With your inpu
 ## Tools
 
 ### Communication
-
 
 We use Microsoft Teams and Google Meet for team calls, and use Slack for direct calls.
 
@@ -83,19 +82,13 @@ You can request to join or post a message in [#ask-nvvs-devops](https://mojdt.sl
 
 ### Learning and Development
 
-- [Pluralsight](https://www.pluralsight.com/), ask for a pluralsight license in the [#pluralsight](https://mojdt.slack.com/archives/CBK9KER8E) Slack channel.
+- [Pluralsight](https://www.pluralsight.com/), [Percipio](https://www.skillsoft.com/percipio-app), [O'Reilly](https://www.oreilly.com/), ask for a license in the [#licenced-offerings-skillsoft-pluralsight-oreilly-linkedinlearning](https://moj.enterprise.slack.com/archives/C06ULRPP737) Slack channel.
 
-- [O'Reilly](https://www.oreilly.com/), ask for a license in the [#oreilly-learning-platform](https://mojdt.slack.com/archives/C042TE0VD7E) Slack channel.
-
-- AWS Training. You can access the OGVA schedule via logging into [here](https://ogva.embrace.tools.aws.dev) using you organisation email address.
-    You can access the schedule directly [here](https://ogva.embrace.tools.aws.dev/front-page-quicklink-1/index.html).
-    For the courses, a reminder:
-    -	if you can no longer attend, please do withdraw from the course through your AWS training account - it will then become available to others
-    -	if your team has a need for training not listed here (or is fully booked), please do let me know and I can enquire about an MOJ-only course
-    -	if a class or course has a cost or isn't part of the OGVA schedule, it is likely not part of the OGVA agreement
+- AWS Training. 
+    The tools mentioned above have AWS training resources. 
+    AWS Certification Exams can be booked by contacting the learning team [#licenced-offerings-skillsoft-pluralsight-oreilly-linkedinlearning](https://moj.enterprise.slack.com/archives/C06ULRPP737) Slack channel.
 
 - [Learn Tech Trello Board](https://trello.com/b/r7ntXcC6/learn-tech) for questions that you have about our Friday learning sessions
-
 
 ### Recommended Reading for New Joiners
 


### PR DESCRIPTION
Corrected the links for organising learning licenses and removed references to the OGVA One Government Value Agreement as this is no longer available.