### PR TITLE
Update Using Git link

### DIFF
--- a/source/documentation/team-guide/best-practices/github.html.md.erb
+++ b/source/documentation/team-guide/best-practices/github.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#nvvs-devopss"
 title: GitHub
-last_reviewed_on: 2024-10-15
+last_reviewed_on: 2024-12-09
 review_in: 3 months
 ---
 # Github
@@ -13,7 +13,7 @@ The NVVS Dev Ops team follows a GitOps style workflow.  Any changes to the syste
 
 ## All changes via Pull Request
 
-All work undertaken by a member of the NVVS Dev Ops team will take place in a branch as per [MoJ Technical Guidance](https://technical-guidance.service.justice.gov.uk/documentation/guides/using-git.html#using-git). An example of creating a branch to work on is [here](../developing-on-a-branch.html).
+All work undertaken by a member of the NVVS Dev Ops team will take place in a branch as per [MoJ Technical Guidance](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/using-git.html). An example of creating a branch to work on is [here](../developing-on-a-branch.html).
 
 ## Commit Early, Commit Often
 


### PR DESCRIPTION
This PR updates the link to guidance for Using Git that has been relocated to Operations Engineering user guide.